### PR TITLE
🔧 Fix package.json - Remove non-existent @radix-ui/react-sheet dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@radix-ui/react-scroll-area": "^1.0.5",
     "@radix-ui/react-select": "^2.0.0",
     "@radix-ui/react-separator": "^1.0.3",
-    "@radix-ui/react-sheet": "^1.0.4",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-switch": "^1.0.3",
     "@radix-ui/react-tabs": "^1.0.4",


### PR DESCRIPTION
🔧 **Fix: Remove non-existent dependency**

## Problem
The deployment was failing because `@radix-ui/react-sheet@^1.0.4` doesn't exist in the npm registry. This package is not part of the official Radix UI library.

## Solution
- Removed the problematic `@radix-ui/react-sheet` dependency from package.json
- This will allow the build process to complete successfully

## Changes
- ❌ Removed: `"@radix-ui/react-sheet": "^1.0.4"`

## Testing
- Build should now complete without npm 404 errors
- All other dependencies remain intact

## Related
- Fixes deployment failure with error: `npm error 404 Not Found - GET https://registry.npmjs.org/@radix-ui%2freact-sheet`
