### PR TITLE
🔧 Fix: Add missing OpenAI dependency to resolve build errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "date-fns": "^2.30.0",
     "lucide-react": "^0.294.0",
     "next": "14.0.3",
+    "openai": "^4.20.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "recharts": "^2.8.0",


### PR DESCRIPTION
## Descripción

Este PR soluciona los errores de build que estaban ocurriendo en Railway debido a dependencias faltantes.

### Cambios realizados:

✅ **Dependencia agregada**:
- `openai: ^4.20.1` - Necesaria para la integración con GPT-4o en `services/openai.ts`

### Problema resuelto:

El error de build era:
```
Cannot find module 'openai' or its corresponding type declarations.
```

### Verificación:

- ✅ Dependencia agregada correctamente
- ✅ Versión compatible con el código existente  
- ✅ No hay conflictos con otras dependencias

Este fix permitirá que los deployments en Railway funcionen correctamente.